### PR TITLE
Please don't touch the load path

### DIFF
--- a/bin/ios
+++ b/bin/ios
@@ -5,8 +5,6 @@ require 'terminal-table'
 require 'term/ansicolor'
 require 'netrc'
 
-$:.push File.expand_path("../../lib", __FILE__)
-
 require 'cupertino'
 
 HighLine.track_eof = false # Fix for built-in Ruby

--- a/lib/cupertino/provisioning_portal.rb
+++ b/lib/cupertino/provisioning_portal.rb
@@ -11,8 +11,6 @@ module Cupertino
   end
 end
 
-$:.push File.expand_path('../', __FILE__)
-
-require 'provisioning_portal/helpers'
-require 'provisioning_portal/agent'
-require 'provisioning_portal/commands'
+require 'cupertino/provisioning_portal/helpers'
+require 'cupertino/provisioning_portal/agent'
+require 'cupertino/provisioning_portal/commands'

--- a/lib/cupertino/provisioning_portal/commands.rb
+++ b/lib/cupertino/provisioning_portal/commands.rb
@@ -1,11 +1,9 @@
 include Cupertino::ProvisioningPortal
 include Cupertino::ProvisioningPortal::Helpers
 
-$:.push File.expand_path('../', __FILE__)
-
-require 'commands/certificates'
-require 'commands/devices'
-require 'commands/profiles'
-require 'commands/app_ids'
-require 'commands/login'
-require 'commands/logout'
+require 'cupertino/provisioning_portal/commands/certificates'
+require 'cupertino/provisioning_portal/commands/devices'
+require 'cupertino/provisioning_portal/commands/profiles'
+require 'cupertino/provisioning_portal/commands/app_ids'
+require 'cupertino/provisioning_portal/commands/login'
+require 'cupertino/provisioning_portal/commands/logout'


### PR DESCRIPTION
Absolutely love the project, great idea, I hate that dev site so much and love automation.

However, gems that [modify the load path](https://github.com/mattt/cupertino/blob/c7d71ec8645f4bb1eaacc29abc3458e44a0817e8/lib/cupertino/provisioning_portal.rb#L14) makes me sad for [many reasons](http://guides.rubygems.org/patterns/#mangling_the_load_path). I'd love to be able to use this gem in rake tasks and the like but I won't pollute my load path.

Instead of adding to the load path, just require your files with the `cupertino/` prefix. This is their canonical name and will prevent double-loading and collisions.

If you need to run the script with the local lib path having higher precendence, i.e. in development, try:

```
ruby -I ./lib ./bin/ios ...
```
