### PR TITLE
Add a profiles:download command to download provisioning profiles.

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ _Crossed out commands are not yet implemented_
 
 - `profiles:list`
 - `profiles:manage:devices`
+- `profiles:download`
 - ~~`profiles:add`~~
 - ~~`profiles:edit`~~
 

--- a/lib/cupertino/provisioning_portal/agent.rb
+++ b/lib/cupertino/provisioning_portal/agent.rb
@@ -146,6 +146,25 @@ module Cupertino
         profiles
       end
 
+      def download_profile(profile)
+        list_profiles(profile.type)
+
+        page.parser.xpath('//fieldset[@id="fs-0"]/table/tbody/tr').each do |row|
+          name = row.at_xpath('td[@class="profile"]//span/text()').to_s.strip rescue nil
+
+          if name == profile.name
+            download_url = row.at_xpath('td[@class="action"]/a')['href'].to_s.strip rescue nil
+
+            self.pluggable_parser.default = Mechanize::Download
+            download = get(download_url)
+            download.save
+            return download.filename
+          end
+        end
+
+        return nil
+      end
+
       def manage_devices_for_profile(profile)
         raise ArgumentError unless block_given?
 

--- a/lib/cupertino/provisioning_portal/commands/profiles.rb
+++ b/lib/cupertino/provisioning_portal/commands/profiles.rb
@@ -67,3 +67,23 @@ command :'profiles:manage:devices' do |c|
 end
 
 alias_command :'profiles:manage', :'profiles:manage:devices'
+
+command :'profiles:download' do |c|
+  c.syntax = 'ios profiles:download'
+  c.summary = 'Downloads the Provisioning Profiles'
+  c.description = ''
+
+  c.action do |args, options|
+    type = args.first.downcase.to_sym rescue nil
+    profiles = try{agent.list_profiles(type ||= :development)}
+    profiles = profiles.find_all{|profile| profile.status == 'Active'}
+
+    say_warning "No active #{type} profiles found." and abort if profiles.empty?
+    profile = choose "Select a profile to download:", *profiles
+    if filename = agent.download_profile(profile)
+      say_ok "Successfully downloaded: '#{filename}'"
+    else
+      say_error "Could not download profile"
+    end
+  end
+end


### PR DESCRIPTION
Works exactly the same way as certificates:download does and filters out any inactive provisioning profiles.

I have also literally _never_ written any ruby code before, so I just pattern matched my way through.  If I've committed some grave ruby error, let me know and I'd be happy to fix.

Thanks! 
