### PR TITLE
Adding distribution type to profiles:manage:devices.

### DIFF
--- a/lib/cupertino/provisioning_portal/commands/profiles.rb
+++ b/lib/cupertino/provisioning_portal/commands/profiles.rb
@@ -37,7 +37,7 @@ command :'profiles:manage:devices' do |c|
 
   c.action do |args, options|
     type = args.first.downcase.to_sym rescue nil
-    profiles = try{agent.list_profiles(:development)}
+    profiles = try{agent.list_profiles(type ||= :development)}
 
     say_warning "No #{type} provisioning profiles found." and abort if profiles.empty?
 


### PR DESCRIPTION
See https://github.com/mattt/cupertino/pull/12, only the first commit now (should have been using a feature branch in the first place, but it was late at night and I forgot).
