### PR TITLE
Fix SSL errors on ruby 1.9.x

### DIFF
--- a/cupertino.gemspec
+++ b/cupertino.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency "mechanize", "~> 2.5.1"
   s.add_dependency "security", "~> 0.1.2"
   s.add_dependency "shenzhen", ">= 0.0.1"
+  s.add_dependency "certified", ">= 0.1.0"
 
   s.files         = Dir["./**/*"].reject { |file| file =~ /\.\/(bin|log|pkg|script|spec|test|vendor)/ }
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/lib/cupertino/provisioning_portal.rb
+++ b/lib/cupertino/provisioning_portal.rb
@@ -1,4 +1,5 @@
 require 'mechanize'
+require 'certified'
 
 module Cupertino
   module ProvisioningPortal


### PR DESCRIPTION
Added the 'certified' gem to prevent SSL errors on ruby 1.9.x such as 
`error: SSL_connect returned=1 errno=0 state=SSLv3 read server certificate B: certificate verify failed.` 
as described on http://martinottenwaelter.fr/2010/12/ruby19-and-the-ssl-error/
