### PR TITLE
bugfix: apple's command for managing devices, which used to submit a for...

### DIFF
--- a/lib/cupertino/provisioning_portal/agent.rb
+++ b/lib/cupertino/provisioning_portal/agent.rb
@@ -226,7 +226,7 @@ module Cupertino
           end
         end
 
-        form.method = 'POST'
+        form.method = 'GET'
         form.submit
       end
 


### PR DESCRIPTION
...m via 'post', now only accepts that form via 'get'.

This change probably happened at the same time that #65 became necessary.

this should fix issue #68.
