### PR TITLE
use proxy settings specified in http_proxy, HTTP_PROXY, http_proxy_user,...

### DIFF
--- a/lib/cupertino/provisioning_portal/agent.rb
+++ b/lib/cupertino/provisioning_portal/agent.rb
@@ -1,5 +1,6 @@
 require 'mechanize'
 require 'security'
+require 'uri'
 require 'json'
 
 module Cupertino
@@ -11,8 +12,40 @@ module Cupertino
         super
         self.user_agent_alias = 'Mac Safari'
 
+        get_proxy_from_env
+
         pw = Security::InternetPassword.find(:server => Cupertino::ProvisioningPortal::HOST)
         @username, @password = pw.attributes['acct'], pw.password if pw
+      end
+
+      def use_proxy(arg)
+        puts "Using proxy #{arg}"
+        puts '-----------'
+        uri = URI.parse(normalize_uri(arg))
+        if uri and uri.user.nil? and uri.password.nil? then
+          # Probably we have http_proxy_* variables?
+          user = (ENV['http_proxy_user'] || ENV['HTTP_PROXY_USER'])
+          pass = (ENV['http_proxy_pass'] || ENV['HTTP_PROXY_PASS'])
+          uri.user = user
+          uri.password = pass
+        end
+        set_proxy(uri.host, uri.port, user, pass)
+        uri
+      end
+
+      ##
+      # Returns an HTTP proxy URI if one is set in the environment variables.
+      def get_proxy_from_env
+        env_proxy = ENV['http_proxy'] || ENV['HTTP_PROXY']
+        return nil if env_proxy.nil? or env_proxy.empty?
+
+        use_proxy(env_proxy)
+      end
+
+      ##
+      # Normalize the URI by adding "http://" if it is missing.
+      def normalize_uri(uri)
+        (uri =~ /^(https?|ftp|file):/) ? uri : "http://#{uri}"
       end
 
       def get(uri, parameters = [], referer = nil, headers = {})
@@ -23,6 +56,7 @@ module Cupertino
 
           return page unless page.respond_to?(:title)
 
+#TODO could rescue Net::HTTP::Persistent::Error here, and if there's a proxy, suggest that the proxy is not available
           case page.title
             when /Sign in with your Apple ID/
               login! and redo


### PR DESCRIPTION
... HTTP_PROXY_USER, http_proxy_pass, HTTP_PROXY_PASS (if any of these are set in the environment).

If these standard environment variables are not set, everything proceeds as usual.

This feature should resolve #61.
