### PR TITLE
Fix the --team option to accept the team name or id

### DIFF
--- a/lib/cupertino/provisioning_portal/agent.rb
+++ b/lib/cupertino/provisioning_portal/agent.rb
@@ -6,7 +6,7 @@ require 'json'
 module Cupertino
   module ProvisioningPortal
     class Agent < ::Mechanize
-      attr_accessor :username, :password, :team, :team_name
+      attr_accessor :username, :password, :team
 
       def initialize
         super
@@ -291,7 +291,7 @@ module Cupertino
 
       def select_team!
         if form = page.form_with(:name => 'saveTeamSelection')
-          team_option = form.radiobutton_with(:value => self.team)
+          team_option = form.radiobutton_with(:value => self.team_id)
           team_option.check
 
           button = form.button_with(:name => 'action:saveTeamSelection!save')

--- a/lib/cupertino/provisioning_portal/commands.rb
+++ b/lib/cupertino/provisioning_portal/commands.rb
@@ -3,7 +3,7 @@ include Cupertino::ProvisioningPortal::Helpers
 
 global_option('-u', '--username USER', 'Username') { |arg| agent.username = arg unless arg.nil? }
 global_option('-p', '--password PASSWORD', 'Password') { |arg| agent.password = arg unless arg.nil? }
-global_option('-tm', '--team TEAM', 'Team') { |arg| agent.team_name = arg unless arg.nil? }
+global_option('-tm', '--team TEAM', 'Team') { |arg| agent.team = arg unless arg.nil? }
 
 require 'cupertino/provisioning_portal/commands/certificates'
 require 'cupertino/provisioning_portal/commands/devices'

--- a/lib/cupertino/provisioning_portal/helpers.rb
+++ b/lib/cupertino/provisioning_portal/helpers.rb
@@ -23,21 +23,29 @@ module Cupertino
               @password ||= pw "Password:"
             end
 
-            def team
+            def team_id
               teams = []
+
               page.form_with(:name => 'saveTeamSelection').radiobuttons.each do |radio|
                 primary = page.search(".label-primary[for=\"#{radio.dom_id}\"]").first.text.strip
                 secondary = page.search(".label-secondary[for=\"#{radio.dom_id}\"]").first.text.strip
-                name = "#{primary}, #{secondary}"
+                team_id = radio.value
+                name = "#{primary}, #{secondary} (#{team_id})"
                 teams << [name, radio.value]
               end
 
-              @team_name ||= choose "Select a team:", *teams.collect(&:first)
-              if team = teams.detect{|e| e.first == @team_name}
-                @team = team.last
+              team_names = teams.collect(&:first)
+              team_ids   = teams.collect(&:last)
+
+              if @team.nil?
+                selected_team_name = choose "Select a team:", *team_names
+                teams.detect { |t| t.first == selected_team_name }.last
+              elsif team_ids.member? @team
+                @team
+              elsif team = teams.detect { |t| t.first.start_with?(@team) }
+                team.last
               else
-                team_names = teams.map { |t| "\"#{t.first}\"" }.join(', ')
-                say_error "Team should be one of the following: #{team_names}" and abort
+                say_error "Team should be a name or identifier" and abort
               end
             end
           end


### PR DESCRIPTION
- Passing the --team option did not skip the "Select a team:" prompt.
- The --team option should accept the name or id of the team.
- Show the team id in the "Select a team:" prompt.
