### PR TITLE
Update :team attribute on Agent to :team_id

### DIFF
--- a/lib/cupertino/provisioning_portal/agent.rb
+++ b/lib/cupertino/provisioning_portal/agent.rb
@@ -9,6 +9,10 @@ module Cupertino
     class Agent < ::Mechanize
       attr_accessor :username, :password, :team_id
 
+      # Maintain backward compatibility
+      alias_method :team, :team_id
+      alias_method :team=, :team_id=
+
       def initialize
         super
 


### PR DESCRIPTION
Fixes an issue introduced in nomad/cupertino#76 where team selection no longer works when using Agent outside of a CLI context.
