### PR TITLE
Isolate CLI required resources

### DIFF
--- a/bin/ios
+++ b/bin/ios
@@ -19,3 +19,4 @@ program :help_formatter, :compact
 default_command :help
 
 require 'cupertino/provisioning_portal'
+require 'cupertino/provisioning_portal/commands'

--- a/lib/cupertino/provisioning_portal.rb
+++ b/lib/cupertino/provisioning_portal.rb
@@ -46,6 +46,4 @@ module Cupertino
   end
 end
 
-require 'cupertino/provisioning_portal/helpers'
 require 'cupertino/provisioning_portal/agent'
-require 'cupertino/provisioning_portal/commands'

--- a/lib/cupertino/provisioning_portal/commands.rb
+++ b/lib/cupertino/provisioning_portal/commands.rb
@@ -1,4 +1,6 @@
 include Cupertino::ProvisioningPortal
+
+require 'cupertino/provisioning_portal/helpers'
 include Cupertino::ProvisioningPortal::Helpers
 
 global_option('-u', '--username USER', 'Username') { |arg| agent.username = arg unless arg.nil? }


### PR DESCRIPTION
This change allows for programmatic usage of cupertino without including Term and Commander.  The Commander include was particularly tricky for programmatic usage as it requires that you set `:version`, `:description`, and automatically adds an `at_exit {}` block.  Previous to this change, my code that used cupertino looked like this:

``` ruby
# Required by Cupertino
require 'term/ansicolor'

# Required by Cupertino
require 'commander/import'
program :version, '1.0.0' # Required by Commander
program :description, '.' # Required by Commander
# Suppress Commander's at_exit block that will always throw an error since this isn't a real Commander program
at_exit { exit! }

require 'cupertino/provisioning_portal'

[...code...]
```
