### PR TITLE
Fix CLI team_id detection

### DIFF
--- a/lib/cupertino/provisioning_portal/helpers.rb
+++ b/lib/cupertino/provisioning_portal/helpers.rb
@@ -37,12 +37,12 @@ module Cupertino
               team_names = teams.collect(&:first)
               team_ids   = teams.collect(&:last)
 
-              if @team.nil?
+              if self.team.nil?
                 selected_team_name = choose "Select a team:", *team_names
                 teams.detect { |t| t.first == selected_team_name }.last
-              elsif team_ids.member? @team
-                @team
-              elsif team = teams.detect { |t| t.first.start_with?(@team) }
+              elsif team_ids.member? self.team
+                self.team
+              elsif team = teams.detect { |t| t.first.start_with?(self.team) }
                 team.last
               else
                 say_error "Team should be a name or identifier" and abort


### PR DESCRIPTION
Fixes the CLI `--team` issue @ksuther found in nomad/cupertino#83.  I didn't see any particular reason why we couldn't just use the `team` accessor instead of the instance variable, but my ruby-foo is weak.  Confirmed that this works for CLI and programmatic usage.

Alternatively, we could abandon the backwards compatibility and deprecate Agent::team_id, but that might require a major version bump.
