### PR TITLE
Fixed typo in profiles:download

### DIFF
--- a/lib/cupertino/provisioning_portal/commands/profiles.rb
+++ b/lib/cupertino/provisioning_portal/commands/profiles.rb
@@ -46,7 +46,7 @@ command :'profiles:download' do |c|
 
     say_warning "No active #{type} profiles found." and abort if profiles.empty?
 
-    profile = profiles.find{|p| profile.name == args.join(" ")} || choose("Select a profile:", *profiles)
+    profile = profiles.find{|p| p.name == args.join(" ")} || choose("Select a profile:", *profiles)
 
     if filename = agent.download_profile(profile)
       say_ok "Successfully downloaded: '#{filename}'"


### PR DESCRIPTION
One of the changes in 41b9bf19bcc45586724b601a9604eee6b59a5884 didn't match the rest of them, causing profiles:download to fail.
