### PR TITLE
add feature: directly add device list file

### DIFF
--- a/lib/cupertino/provisioning_portal/agent.rb
+++ b/lib/cupertino/provisioning_portal/agent.rb
@@ -159,6 +159,40 @@ module Cupertino
         end
       end
 
+      def add_device_list_file(device_list_file)
+        return if device_list_file.empty?
+
+        get('https://developer.apple.com/account/ios/device/deviceCreate.action')
+
+        begin
+          file = open(device_list_file)
+
+          form = page.form_with(:name => 'deviceImport') or raise UnexpectedContentError
+
+          upload = form.file_uploads.first
+          upload.file_name = file.path
+          puts file.path
+          form.radiobuttons.first.check()
+          form.submit
+
+          if form = page.form_with(:name => 'deviceSubmit')
+            form.method = 'POST'
+            form.field_with(:name => 'deviceNames').name = 'name'
+            form.field_with(:name => 'deviceNumbers').name = 'deviceNumber'
+            form.submit
+          elsif form = page.form_with(:name => 'deviceImport')
+            form.submit
+          else
+            raise UnexpectedContentError
+          end
+        rescue Exception => e
+          puts e.message
+          puts e.backtrace.inspect
+        ensure
+          file.close
+        end
+      end
+
       def list_profiles(type = :development)
         url = case type
               when :development

--- a/lib/cupertino/provisioning_portal/commands/devices.rb
+++ b/lib/cupertino/provisioning_portal/commands/devices.rb
@@ -29,13 +29,18 @@ end
 alias_command :devices, :'devices:list'
 
 command :'devices:add' do |c|
-  c.syntax = 'ios devices:add DEVICE_NAME=DEVICE_ID [...]'
+  c.syntax = 'ios devices:add [-f filename | DEVICE_NAME=DEVICE_ID [...]]'
   c.summary = 'Adds the a device to the Provisioning Portal'
   c.description = ''
+  c.option '-f filename', 'device list file'
 
   c.action do |args, options|
-    say_error "Missing arguments, expected DEVICE_NAME=DEVICE_ID" and abort if args.nil? or args.empty?
-
+    if(options.f)
+      agent.add_device_list_file(options.f)
+      say_ok "Added device list file"
+      return
+    end
+    say_error "Missing arguments, expected DEVICE_NAME=DEVICE_ID or -f device_list_filename" and abort if args.nil? or args.empty?
     devices = []
     args.each do |arg|
       components = arg.strip.gsub(/"/, '').split(/\=/)


### PR DESCRIPTION
I have the device list file and it would be helpful if I can directly add the file rather than using the command line parameter.
