### PR TITLE
Specifying a username on the command line now looks up that username's password in Keychain

### DIFF
--- a/lib/cupertino/provisioning_portal/agent.rb
+++ b/lib/cupertino/provisioning_portal/agent.rb
@@ -29,6 +29,13 @@ module Cupertino
         @username, @password = pw.attributes['acct'], pw.password if pw
       end
 
+      def username=(value)
+          @username = value
+          
+          pw = Security::InternetPassword.find(:a => self.username, :server => Cupertino::ProvisioningPortal::HOST)
+          @password = pw.password if pw
+      end
+
       def get(uri, parameters = [], referer = nil, headers = {})
         uri = ::File.join("https://#{Cupertino::ProvisioningPortal::HOST}", uri) unless /^https?/ === uri
 


### PR DESCRIPTION
This makes it possible to use cupertino with multiple accounts without having to specify passwords as command line arguments. Without this the password would get set from the first matching result for the developer portal host, then username would get updated from the options afterwards.
