### PR TITLE
Update login for new developer center form

### DIFF
--- a/lib/cupertino/provisioning_portal/agent.rb
+++ b/lib/cupertino/provisioning_portal/agent.rb
@@ -290,9 +290,9 @@ module Cupertino
       private
 
       def login!
-        if form = page.form_with(:name => 'form2')
-          form.appleId = self.username
-          form.accountPassword = self.password
+        if form = page.form_with(:name => 'appleConnectForm')
+          form.theAccountName = self.username
+          form.theAccountPW = self.password
           form.submit
         end
       end


### PR DESCRIPTION
Updated cupertino's login because of (yet more!) changes made by Apple to their login form.

Fixes #129.
