### PR TITLE
generic search for login form/fields so minor changes don't break auth

### DIFF
--- a/lib/cupertino/provisioning_portal/agent.rb
+++ b/lib/cupertino/provisioning_portal/agent.rb
@@ -290,9 +290,10 @@ module Cupertino
       private
 
       def login!
-        if form = page.form_with(:name => 'form2')
-          form.appleId = self.username
-          form.accountPassword = self.password
+        if form = page.forms.first
+          form.fields_with(type: 'text').first.value = self.username
+          form.fields_with(type: 'password').first.value = self.password
+
           form.submit
         end
       end


### PR DESCRIPTION
Looks like apple changed the login form back to theAccountName - hopefully this is a less fragile solution
