### PR TITLE
Portal returns deviceNumber parameter fix

### DIFF
--- a/lib/cupertino/provisioning_portal/agent.rb
+++ b/lib/cupertino/provisioning_portal/agent.rb
@@ -124,7 +124,7 @@ module Cupertino
           device.name = row['name']
           device.enabled = (row['status'] == 'c' ? 'Y' : 'N')
           device.device_id = row['deviceId']
-          device.udid = row['deviceName']
+          device.udid = row['deviceNumber']
           devices << device
         end
 


### PR DESCRIPTION
When loading devices, the portal now returns "deviceNumber" parameter instead of "deviceName" for UDID identifier. This pull request fixes issue that devices are displayed correctly.
