### PR TITLE
Added expiration time to profiles list

### DIFF
--- a/lib/cupertino/provisioning_portal.rb
+++ b/lib/cupertino/provisioning_portal.rb
@@ -26,7 +26,7 @@ module Cupertino
       end
     end
 
-    class ProvisioningProfile < Struct.new(:name, :type, :app_id, :status, :download_url, :edit_url)
+    class ProvisioningProfile < Struct.new(:name, :type, :app_id, :status, :expires, :download_url, :edit_url)
       def to_s
         "#{self.name}"
       end

--- a/lib/cupertino/provisioning_portal/agent.rb
+++ b/lib/cupertino/provisioning_portal/agent.rb
@@ -202,6 +202,7 @@ module Cupertino
           profile.type = type
           profile.app_id = row['appId']['appIdId']
           profile.status = row['status']
+          profile.expires = row['dateExpire']
           profile.download_url = "https://developer.apple.com/account/ios/profile/profileContentDownload.action?displayId=#{row['provisioningProfileId']}"
           profile.edit_url = "https://developer.apple.com/account/ios/profile/profileEdit.action?provisioningProfileId=#{row['provisioningProfileId']}"
           profiles << profile

--- a/lib/cupertino/provisioning_portal/commands/profiles.rb
+++ b/lib/cupertino/provisioning_portal/commands/profiles.rb
@@ -1,3 +1,5 @@
+require 'time'
+
 command :'profiles:list' do |c|
   c.syntax = 'ios profiles:list'
   c.summary = 'Lists the Provisioning Profiles'
@@ -11,7 +13,7 @@ command :'profiles:list' do |c|
     say_warning "No #{type} provisioning profiles found." and abort if profiles.empty?
 
     table = Terminal::Table.new do |t|
-      t << ["Profile", "App ID", "Status"]
+      t << ["Profile", "App ID", "Expiration", "Status"]
       t.add_separator
       profiles.each do |profile|
         status = case profile.status
@@ -21,7 +23,7 @@ command :'profiles:list' do |c|
                    profile.status.green
                  end
 
-        t << [profile.name, profile.app_id, status]
+        t << [profile.name, profile.app_id, Time.parse(profile.expires).localtime, status]
       end
     end
 


### PR DESCRIPTION
I'm working on a cron job to periodically check my certificates and provisioning profiles to give my build automation team advanced warning when expirations are about to happen, so that we don't have any interrupted builds.

The Certificates list shows an expiration date, but the provisioning profiles didn't.  So therefore I added the expiration column to the provisioning profiles list.

If you don't like the time format, I can change it.  Currently the output looks like so:

```
+---------------------------------------------+------------+---------------------------+---------+
| Profile                                     | App ID     | Expiration                | Status  |
+---------------------------------------------+------------+---------------------------+---------+
| ********                                    | ********** | 2013-08-19 10:53:05 -1000 | Expired |
.....
```
