### PR TITLE
Updated profile identifier JSON key (#163)

### DIFF
--- a/lib/cupertino/provisioning_portal/agent.rb
+++ b/lib/cupertino/provisioning_portal/agent.rb
@@ -215,7 +215,7 @@ module Cupertino
           profile.expiration = (Time.parse(row['dateExpire']) rescue nil)
           profile.download_url = "https://developer.apple.com/account/ios/profile/profileContentDownload.action?displayId=#{row['provisioningProfileId']}"
           profile.edit_url = "https://developer.apple.com/account/ios/profile/profileEdit.action?provisioningProfileId=#{row['provisioningProfileId']}"
-          profile.identifier = row['appId']['identifier']
+          profile.identifier = row['UUID']
           profiles << profile
         end
 


### PR DESCRIPTION
In cupertino `1.2.2` (latest) I'm seeing a similar error to #163 in a slightly different location when trying to download profiles. It seems that Apple's JSON has been updated once again, and this tweak appears to fix the issue for me.

``` bash
/Library/Ruby/Gems/2.0.0/gems/cupertino-1.2.2/lib/cupertino/provisioning_portal/agent.rb:218:in `block in list_profiles': undefined method `[]' for nil:NilClass (NoMethodError)
    from /Library/Ruby/Gems/2.0.0/gems/cupertino-1.2.2/lib/cupertino/provisioning_portal/agent.rb:210:in `each'
    from /Library/Ruby/Gems/2.0.0/gems/cupertino-1.2.2/lib/cupertino/provisioning_portal/agent.rb:210:in `list_profiles'
    from /Library/Ruby/Gems/2.0.0/gems/cupertino-1.2.2/lib/cupertino/provisioning_portal/commands/profiles.rb:65:in `block (3 levels) in <top (required)>'
    from /Library/Ruby/Gems/2.0.0/gems/cupertino-1.2.2/lib/cupertino/provisioning_portal/helpers.rb:58:in `try'
    from /Library/Ruby/Gems/2.0.0/gems/cupertino-1.2.2/lib/cupertino/provisioning_portal/commands/profiles.rb:65:in `block (2 levels) in <top (required)>'
    from /Library/Ruby/Gems/2.0.0/gems/commander-4.2.1/lib/commander/command.rb:180:in `call'
    from /Library/Ruby/Gems/2.0.0/gems/commander-4.2.1/lib/commander/command.rb:180:in `call'
    from /Library/Ruby/Gems/2.0.0/gems/commander-4.2.1/lib/commander/command.rb:155:in `run'
    from /Library/Ruby/Gems/2.0.0/gems/commander-4.2.1/lib/commander/runner.rb:421:in `run_active_command'
    from /Library/Ruby/Gems/2.0.0/gems/commander-4.2.1/lib/commander/runner.rb:81:in `run!'
    from /Library/Ruby/Gems/2.0.0/gems/commander-4.2.1/lib/commander/delegates.rb:8:in `run!'
    from /Library/Ruby/Gems/2.0.0/gems/commander-4.2.1/lib/commander/import.rb:10:in `block in <top (required)>'
```
