### PR TITLE
Added CSV format option, UDID for profiles

### DIFF
--- a/bin/ios
+++ b/bin/ios
@@ -3,6 +3,7 @@
 require 'commander/import'
 require 'terminal-table'
 require 'term/ansicolor'
+require 'csv'
 
 require 'cupertino'
 

--- a/lib/cupertino/provisioning_portal/agent.rb
+++ b/lib/cupertino/provisioning_portal/agent.rb
@@ -9,7 +9,7 @@ require 'logger'
 module Cupertino
   module ProvisioningPortal
     class Agent < ::Mechanize
-      attr_accessor :username, :password, :team
+      attr_accessor :username, :password, :team, :format
 
       def initialize
         super

--- a/lib/cupertino/provisioning_portal/commands.rb
+++ b/lib/cupertino/provisioning_portal/commands.rb
@@ -8,6 +8,7 @@ global_option('-p', '--password PASSWORD', 'Password') { |arg| agent.password = 
 global_option('--team TEAM', 'Team') { |arg| agent.team = arg if arg }
 global_option('--info', 'Set log level to INFO') { agent.log.level = Logger::INFO }
 global_option('--debug', 'Set log level to DEBUG') { agent.log.level = Logger::DEBUG }
+global_option('--format [table|csv]', 'Set output format (default: table)') { |arg| agent.format = arg if arg }
 
 require 'cupertino/provisioning_portal/commands/certificates'
 require 'cupertino/provisioning_portal/commands/devices'

--- a/lib/cupertino/provisioning_portal/commands/app_ids.rb
+++ b/lib/cupertino/provisioning_portal/commands/app_ids.rb
@@ -11,26 +11,38 @@ command :'app_ids:list' do |c|
   c.action do |args, options|
     app_ids = try{agent.list_app_ids}
 
-    title = "Legend: #{COLORS_BY_PROPERTY_VALUES.collect{|k, v| k.send(v)}.join(', ')}"
-    table = Terminal::Table.new :title => title do |t|
-      t << ["Bundle Seed ID", "Description", "Development", "Distribution"]
-      app_ids.each do |app_id|
-        t << :separator
+    if (agent.format == "csv")
+      csv_string = CSV.generate do |csv|
+        csv << ["Bundle Seed ID", "Description"]
 
-        row = [app_id.bundle_seed_id, app_id.description]
-        [app_id.development_properties, app_id.distribution_properties].each do |properties|
-          values = []
-          properties.each do |key, value|
-            color = COLORS_BY_PROPERTY_VALUES[value] || :reset
-            values << key.sub(/\:$/, "").send(color)
-          end
-          row << values.join("\n")
+        app_ids.each do |app_id|
+          csv << [app_id.bundle_seed_id, app_id.description]
         end
-        t << row
       end
-    end
 
-    puts table
+      puts csv_string
+    else
+      title = "Legend: #{COLORS_BY_PROPERTY_VALUES.collect{|k, v| k.send(v)}.join(', ')}"
+      table = Terminal::Table.new :title => title do |t|
+        t << ["Bundle Seed ID", "Description", "Development", "Distribution"]
+        app_ids.each do |app_id|
+          t << :separator
+
+          row = [app_id.bundle_seed_id, app_id.description]
+          [app_id.development_properties, app_id.distribution_properties].each do |properties|
+            values = []
+            properties.each do |key, value|
+              color = COLORS_BY_PROPERTY_VALUES[value] || :reset
+              values << key.sub(/\:$/, "").send(color)
+            end
+            row << values.join("\n")
+          end
+          t << row
+        end
+      end
+
+      puts table
+    end
   end
 end
 

--- a/lib/cupertino/provisioning_portal/commands/certificates.rb
+++ b/lib/cupertino/provisioning_portal/commands/certificates.rb
@@ -6,24 +6,36 @@ command :'certificates:list' do |c|
     type = args.first.downcase.to_sym rescue nil
     certificates = try{agent.list_certificates(type ||= :development)}
 
-    say_warning "No #{type} certificates found." and abort if certificates.empty?
+    if (agent.format == "csv")
+      csv_string = CSV.generate do |csv|
+        csv << ["Name", "Type", "Expiration Date", "Status"]
 
-    table = Terminal::Table.new do |t|
-      t << ["Name", "Type", "Expiration Date", "Status"]
-      t.add_separator
-      certificates.each do |certificate|
-        status = case certificate.status
-                   when "Issued"
-                     certificate.status.green
-                   else
-                     certificate.status.red
-                 end
-
-        t << [certificate.name, certificate.type, certificate.expiration, status]
+        certificates.each do |certificate|
+          csv << [certificate.name, certificate.type, certificate.expiration, certificate.status]
+        end
       end
-    end
 
-    puts table
+      puts csv_string
+    else
+      say_warning "No #{type} certificates found." and abort if certificates.empty?
+
+      table = Terminal::Table.new do |t|
+        t << ["Name", "Type", "Expiration Date", "Status"]
+        t.add_separator
+        certificates.each do |certificate|
+          status = case certificate.status
+                     when "Issued"
+                       certificate.status.green
+                     else
+                       certificate.status.red
+                   end
+
+          t << [certificate.name, certificate.type, certificate.expiration, status]
+        end
+      end
+
+      puts table
+    end
   end
 end
 

--- a/lib/cupertino/provisioning_portal/commands/devices.rb
+++ b/lib/cupertino/provisioning_portal/commands/devices.rb
@@ -5,23 +5,35 @@ command :'devices:list' do |c|
   c.action do |args, options|
     devices = try{agent.list_devices}
 
-    number_of_devices = devices.compact.length
-    number_of_additional_devices = devices.length - number_of_devices
+    if (agent.format == "csv")
+      csv_string = CSV.generate do |csv|
+        csv << ["Device Name", "Device Identifier", "Enabled"]
 
-    title = "Listing #{pluralize(number_of_devices, 'device')} "
-    title += "(You can register #{pluralize(number_of_additional_devices, 'additional device')})" if number_of_additional_devices > 0
-
-    table = Terminal::Table.new :title => title do |t|
-      t << ["Device Name", "Device Identifier", "Enabled"]
-      t.add_separator
-      devices.compact.each do |device|
-        t << [device.name, device.udid, device.enabled]
+        devices.compact.each do |device|
+          csv << [device.name, device.udid, device.enabled]
+        end
       end
+
+      puts csv_string
+    else
+      number_of_devices = devices.compact.length
+      number_of_additional_devices = devices.length - number_of_devices
+
+      title = "Listing #{pluralize(number_of_devices, 'device')} "
+      title += "(You can register #{pluralize(number_of_additional_devices, 'additional device')})" if number_of_additional_devices > 0
+
+      table = Terminal::Table.new :title => title do |t|
+        t << ["Device Name", "Device Identifier", "Enabled"]
+        t.add_separator
+        devices.compact.each do |device|
+          t << [device.name, device.udid, device.enabled]
+        end
+      end
+
+      table.align_column 2, :center
+
+      puts table
     end
-
-    table.align_column 2, :center
-
-    puts table
   end
 end
 

--- a/lib/cupertino/provisioning_portal/commands/profiles.rb
+++ b/lib/cupertino/provisioning_portal/commands/profiles.rb
@@ -7,25 +7,37 @@ command :'profiles:list' do |c|
   c.action do |args, options|
     type = (options.type.downcase.to_sym if options.type) || :development
     profiles = try{agent.list_profiles(type)}
-
-    say_warning "No #{type} provisioning profiles found." and abort if profiles.empty?
-
-    table = Terminal::Table.new do |t|
-      t << ["Profile", "App ID", "Expiration", "Status"]
-      t.add_separator
-      profiles.each do |profile|
-        status = case profile.status
-                 when "Invalid"
-                   profile.status.red
-                 else
-                   profile.status.green
-                 end
-
-        t << [profile.name, profile.app_id, profile.expiration, status]
+    
+    if (agent.format == "csv")
+      csv_string = CSV.generate do |csv|
+          csv << ["Profile", "App ID", "UUID", "Expiration", "Status"]
+          
+          profiles.each do |profile|
+              csv << [profile.name, profile.app_id, profile.identifier, profile.expiration, profile.status]
+          end
       end
-    end
+      
+      puts csv_string
+    else
+      say_warning "No #{type} provisioning profiles found." and abort if profiles.empty?
 
-    puts table
+      table = Terminal::Table.new do |t|
+        t << ["Profile", "App ID", "UUID", "Expiration", "Status"]
+        t.add_separator
+        profiles.each do |profile|
+          status = case profile.status
+                   when "Invalid"
+                     profile.status.red
+                   else
+                     profile.status.green
+                   end
+
+          t << [profile.name, profile.app_id, profile.identifier, profile.expiration, status]
+        end
+      end
+
+      puts table
+    end
   end
 end
 


### PR DESCRIPTION
Added CSV format option to listing commands (profiles:list), by specifying --format csv. Closes #144 and deprecates "CupertinoPro" gem, which I made previously.

Also adds UDID back when listing profiles (needed by multiple bash scripts lying around).
