### PR TITLE
Fix CSV output of profiles:manage:devices:list

### DIFF
--- a/lib/cupertino/provisioning_portal/commands/profiles.rb
+++ b/lib/cupertino/provisioning_portal/commands/profiles.rb
@@ -211,12 +211,12 @@ command :'profiles:manage:devices:list' do |c|
              when :csv
                CSV.generate do |csv|
                  csv << ["Device Name", "Device Identifier", "Active"]
-
-                 list.values.each do |devices|
-                   devices.each do |device|
-                     csv << [device.name, device.udid, "Y"]
-                   end
-                 end
+                  list[:on].each do |device|
+                    t << [device.name, device.udid, "Y"]
+                  end
+                  list[:off].each do |device|
+                    t << [device.name, device.udid, "N"]
+                  end
                end
              else
                 title = "Listing devices for provisioning profile #{profile.name}"

--- a/lib/cupertino/provisioning_portal/commands/profiles.rb
+++ b/lib/cupertino/provisioning_portal/commands/profiles.rb
@@ -212,10 +212,10 @@ command :'profiles:manage:devices:list' do |c|
                CSV.generate do |csv|
                  csv << ["Device Name", "Device Identifier", "Active"]
                   list[:on].each do |device|
-                    t << [device.name, device.udid, "Y"]
+                    csv << [device.name, device.udid, "Y"]
                   end
                   list[:off].each do |device|
-                    t << [device.name, device.udid, "N"]
+                    csv << [device.name, device.udid, "N"]
                   end
                end
              else


### PR DESCRIPTION
It was always listing devices as active, event when they were not.
