### PR TITLE
Fix conflicting commender version with shenzhen

### DIFF
--- a/cupertino.gemspec
+++ b/cupertino.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.summary     = "Cupertino"
   s.description = "A command-line interface for the iOS Provisioning Portal"
 
-  s.add_dependency "commander", "~> 4.2.0"
+  s.add_dependency "commander", "~> 4.3.0"
   s.add_dependency "terminal-table", "~> 1.4.5"
   s.add_dependency "term-ansicolor", "~> 1.0.7"
   s.add_dependency "mechanize", "~> 2.5.1"


### PR DESCRIPTION
Hi,

I tried to use latest version of [shenzen] and cupertino by referencing from Gemfle.

```rb
source 'https://rubygems.org'

gem 'cupertino', '1.3.0'
gem 'shenzhen', '0.13.1'
```

However, they are depending on different versions of [commander] gem.

- https://github.com/nomad/cupertino/blob/1.3.0/cupertino.gemspec#L17
- https://github.com/nomad/shenzhen/blob/master/shenzhen.gemspec#L17

```
Bundler could not find compatible versions for gem "commander":
  In Gemfile:
    cupertino (= 1.3.0) ruby depends on
      commander (~> 4.2.0) ruby

    shenzhen (= 0.13.1) ruby depends on
      commander (4.3.0)
```

So I updated cupertino's depending version.

Thanks. 

[shenzen]: https://github.com/nomad/shenzhen
[commander]: https://github.com/tj/commander