### PR TITLE
Relaxed overly strict dependencies to allow semver minor version upgrades

### DIFF
--- a/cupertino.gemspec
+++ b/cupertino.gemspec
@@ -14,14 +14,14 @@ Gem::Specification.new do |s|
   s.summary     = "Cupertino"
   s.description = "A command-line interface for the iOS Provisioning Portal"
 
-  s.add_dependency "commander", "~> 4.3"
-  s.add_dependency "highline", ">= 1.7.1"
-  s.add_dependency "terminal-table", "~> 1.4.5"
-  s.add_dependency "term-ansicolor", "~> 1.0.7"
-  s.add_dependency "mechanize", "~> 2.5.1"
-  s.add_dependency "nokogiri", "~> 1.6.3"
-  s.add_dependency "security", "~> 0.1.2"
-  s.add_dependency "certified", "~> 1.0.0"
+  s.add_dependency "commander",       [ "~> 4.3" ]
+  s.add_dependency "highline",        [ ">= 1.7.1", "~> 1.7" ]
+  s.add_dependency "terminal-table",  [ ">= 1.4.5", "~> 1.4" ]
+  s.add_dependency "term-ansicolor",  [ ">= 1.0.7", "~> 1.0" ]
+  s.add_dependency "mechanize",       [ ">= 2.5.1", "~> 2.5" ]
+  s.add_dependency "nokogiri",        [ ">= 1.6.3", "~> 1.6" ]
+  s.add_dependency "security",        [ ">= 0.1.2", "~> 0.1" ]
+  s.add_dependency "certified",       [ "~> 1.0" ]
 
   s.add_development_dependency "rspec"
   s.add_development_dependency "rake"


### PR DESCRIPTION
The current dependencies only allow path level updates and as such are very restrictive and are causing some dependency issues with other libraries, e.g. https://github.com/KrauseFx/fastlane
