### PR TITLE
Fixing command ios certificates:list to accept the type option like others

### DIFF
--- a/lib/cupertino/provisioning_portal/commands/certificates.rb
+++ b/lib/cupertino/provisioning_portal/commands/certificates.rb
@@ -1,10 +1,12 @@
 command :'certificates:list' do |c|
-  c.syntax = 'ios certificates:list [development|distribution]'
+  c.syntax = 'ios certificates:list'
   c.summary = 'Lists the Certificates'
 
+  c.option '--type [TYPE]', [:development, :distribution], "Type of certificate (development or distribution; defaults to development)"
+
   c.action do |args, options|
-    type = args.first.downcase.to_sym rescue nil
-    certificates = try{agent.list_certificates(type ||= :development)}
+    type = (options.type.downcase.to_sym if options.type) || :development
+    certificates = try{agent.list_certificates(type)}
 
     say_warning "No #{type} certificates found." and abort if certificates.empty?
 
@@ -44,7 +46,7 @@ command :'certificates:download' do |c|
   c.syntax = 'ios certificates:download [NAME]'
   c.summary = 'Downloads the Certificates'
 
-  c.option '--type [TYPE]', [:development, :distribution], "Type of profile (development or distribution; defaults to development)"
+  c.option '--type [TYPE]', [:development, :distribution], "Type of certificate (development or distribution; defaults to development)"
 
   c.action do |args, options|
     type = (options.type.downcase.to_sym if options.type) || :development


### PR DESCRIPTION
The `ios certificates:list` command use to take options like `development` or `distribution` which does not match other command option types.

There was also a typo in the option description.
