### PR TITLE
Allow authentication through environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ $ ios login
 
 _Credentials are saved in the Keychain. You will not be prompted for your username or password by commands while you are logged in. (Mac only)_
 
+Alternatively, username and password can also be provided by setting the
+`IOS_USERNAME` and `IOS_PASSWORD` environment variables respectively.
+
 ### Devices
 
 ```

--- a/lib/cupertino/provisioning_portal/agent.rb
+++ b/lib/cupertino/provisioning_portal/agent.rb
@@ -27,15 +27,21 @@ module Cupertino
           set_proxy(uri.host, uri.port, user || uri.user, password || uri.password)
         end
 
-        pw = Security::InternetPassword.find(:server => Cupertino::ProvisioningPortal::HOST)
-        @username, @password = pw.attributes['acct'], pw.password if pw
+        if ENV['IOS_USERNAME'] and ENV['IOS_PASSWORD']
+          @username, @password = ENV['IOS_USERNAME'], ENV['IOS_PASSWORD']
+        else
+          pw = Security::InternetPassword.find(:server => Cupertino::ProvisioningPortal::HOST)
+          @username, @password = pw.attributes['acct'], pw.password if pw
+        end
       end
 
       def username=(value)
         @username = value
 
-        pw = Security::InternetPassword.find(:a => self.username, :server => Cupertino::ProvisioningPortal::HOST)
-        @password = pw.password if pw
+        if not(@password and ENV['IOS_PASSWORD'])
+          pw = Security::InternetPassword.find(:a => self.username, :server => Cupertino::ProvisioningPortal::HOST)
+          @password = pw.password if pw
+        end
       end
 
       def get(uri, parameters = [], referer = nil, headers = {})


### PR DESCRIPTION
We currently face the problem that we want to store username and password for multiple accounts outside of the OSX Keychain in order to facilitate the integration of cupertino into our setup and CI process.

As such this PR extends the agent code to optionally fetch username and password for the dev center accounts not from Keychain but from the environment variables IOS_USERNAME and IOS_PASSWORD which can then be filled from other tools like vault et al.